### PR TITLE
Clean up `scaffolding_scripts_and_styles()`

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -101,7 +101,6 @@ function scaffolding_theme_support() {
 	);
 	*/
 
-
 	add_theme_support( 'automatic-feed-links' );					// rss thingy
 
 	// to add header image support go here: http://themble.com/support/adding-header-background-image-support/


### PR DESCRIPTION
I believe that the `wp_enqueue_scripts` hook only fires on the front-end, so there isn't really a need for the `is_admin()` check. Also `wp_enqueue_script/style()` will take care of registering the script/style, so there's no need to register and enqueue separately.
