### PR TITLE
commonWP Support

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -51,6 +51,8 @@ require_once SCAFFOLDING_INCLUDE_PATH . 'tinymce-settings.php';
 if ( class_exists( 'GFForms' ) ) {
 	require_once SCAFFOLDING_INCLUDE_PATH . 'gf-customizations.php';
 }
+// commonWP Support https://wordpress.org/plugins/commonwp/
+require_once SCAFFOLDING_INCLUDE_PATH . 'commonwp.php';
 
 
 /************************************

--- a/functions.php
+++ b/functions.php
@@ -35,8 +35,6 @@
  * 11.0 - Custom/Additional Functions
  */
 
-// Set to true to use jsdeliver.com CDN for libraries.
-define( 'SCAFFOLDING_USE_JSDELIVR_CDN', false );
 define( 'SCAFFOLDING_INCLUDE_PATH', dirname( __FILE__ ) . '/includes/' );
 
 
@@ -74,111 +72,41 @@ function scaffolding_scripts_and_styles() {
 
 	// Main stylesheet.
 	$theme_css_version = filemtime( get_theme_file_path( '/css/style.css' ) );
-	scaffolding_enqueue_style( 'scaffolding-stylesheet', get_stylesheet_directory_uri() . '/css/style.css', array(), $theme_css_version );
+	wp_enqueue_style( 'scaffolding-stylesheet', get_stylesheet_directory_uri() . '/css/style.css', array(), $theme_css_version );
 
 	// Font Awesome (icon set) - https://fontawesome.com/.
-	scaffolding_enqueue_style( 'scaffolding-fontawesome', get_stylesheet_directory_uri() . '/css/libs/fontawesome/fontawesome-all.css', array(), '5.0.13' );
+	wp_enqueue_style( 'scaffolding-fontawesome', get_stylesheet_directory_uri() . '/css/libs/fontawesome/fontawesome-all.css', array(), '5.0.13' );
 
 	// Modernizr - http://modernizr.com/.
 	// update this to include only what you need to test.
-	scaffolding_enqueue_script( 'scaffolding-modernizr', get_stylesheet_directory_uri() . '/libs/js/custom-modernizr.min.js', array(), '3.6.0', false );
+	wp_enqueue_script( 'scaffolding-modernizr', get_stylesheet_directory_uri() . '/libs/js/custom-modernizr.min.js', array(), '3.6.0', false );
 
 	/**
 	 * Add to wp_footer()
 	 */
 
 	// Retina.js - http://imulus.github.io/retinajs/.
-	scaffolding_enqueue_script( 'scaffolding-retinajs', get_stylesheet_directory_uri() . '/libs/js/retina.min.js', array(), '2.1.2', true );
+	wp_enqueue_script( 'scaffolding-retinajs', get_stylesheet_directory_uri() . '/libs/js/retina.min.js', array(), '2.1.2', true );
 
 	// Doubletaptogo (dropdown nav tapping for touch devices) - https://github.com/dachcom-digital/jquery-doubletaptogo.
-	scaffolding_enqueue_script( 'scaffolding-doubletaptogo-js', get_stylesheet_directory_uri() . '/libs/js/jquery.dcd.doubletaptogo.min.js', array( 'jquery' ), '3.0.2', true );
+	wp_enqueue_script( 'scaffolding-doubletaptogo-js', get_stylesheet_directory_uri() . '/libs/js/jquery.dcd.doubletaptogo.min.js', array( 'jquery' ), '3.0.2', true );
 
 	// Magnific Popup (lightbox) - http://dimsemenov.com/plugins/magnific-popup/.
-	scaffolding_enqueue_script( 'scaffolding-magnific-popup-js', get_stylesheet_directory_uri() . '/libs/js/jquery.magnific-popup.min.js', array( 'jquery' ), '1.1.0', true );
+	wp_enqueue_script( 'scaffolding-magnific-popup-js', get_stylesheet_directory_uri() . '/libs/js/jquery.magnific-popup.min.js', array( 'jquery' ), '1.1.0', true );
 
 	// SelectWoo - https://github.com/woocommerce/selectWoo.
-	scaffolding_enqueue_script( 'scaffolding-selectwoo', get_stylesheet_directory_uri() . '/libs/js/selectWoo.full.min.js', array( 'jquery' ), '1.0.2', true );
+	wp_enqueue_script( 'scaffolding-selectwoo', get_stylesheet_directory_uri() . '/libs/js/selectWoo.full.min.js', array( 'jquery' ), '1.0.2', true );
 
 	// Comment reply script for threaded comments.
 	if ( is_singular() && comments_open() && ( 1 === get_option( 'thread_comments' ) ) ) {
-		scaffolding_enqueue_script( 'comment-reply' );
+		wp_enqueue_script( 'comment-reply' );
 	}
 
 	// Add Scaffolding scripts file in the footer.
 	$theme_js_version = filemtime( get_theme_file_path( '/js/scripts.js' ) );
-	scaffolding_enqueue_script( 'scaffolding-js', get_stylesheet_directory_uri() . '/js/scripts.js', array( 'jquery' ), $theme_js_version, true );
+	wp_enqueue_script( 'scaffolding-js', get_stylesheet_directory_uri() . '/js/scripts.js', array( 'jquery' ), $theme_js_version, true );
 
 } // end scaffolding_scripts_and_styles()
-
-/**
- * Enqueue a CSS stylesheet.
- *
- * Registers the style if source provided (does NOT overwrite) and enqueues.
- *
- * Calls wp_enqueue_style after making any needed modifications.
- *
- * @param string           $handle Name of the stylesheet. Should be unique.
- * @param string           $src    Full URL of the stylesheet, or path of the stylesheet relative to the WordPress root directory.
- *                                 Default empty.
- * @param array            $deps   Optional. An array of registered stylesheet handles this stylesheet depends on. Default empty array.
- * @param string|bool|null $ver    Optional. String specifying stylesheet version number, if it has one, which is added to the URL
- *                                 as a query string for cache busting purposes. If version is set to false, a version
- *                                 number is automatically added equal to current installed WordPress version.
- *                                 If set to null, no version is added.
- * @param string           $media  Optional. The media for which this stylesheet has been defined.
- *                                 Default 'all'. Accepts media types like 'all', 'print' and 'screen', or media queries like
- *                                 '(orientation: portrait)' and '(max-width: 640px)'.
- * @return void
- */
-function scaffolding_enqueue_style( $handle, $src = '', $deps = array(), $ver = false, $media = 'all' ) {
-	if ( SCAFFOLDING_USE_JSDELIVR_CDN ) {
-		switch ( $handle ) {
-			case 'scaffolding-fontawesome':
-				$src = 'https://cdn.jsdelivr.net/gh/FortAwesome/Font-Awesome@' . $ver . '/web-fonts-with-css/css/fontawesome-all.min.css';
-				break;
-		}
-	}
-	wp_enqueue_style( $handle, $src, $deps, $ver, $media );
-}
-
-/**
- * Enqueue a script.
- *
- * Registers the script if $src provided (does NOT overwrite), and enqueues it.
- *
- * Calls wp_enqueue_script after making any needed modifications.
- *
- * @param string           $handle    Name of the script. Should be unique.
- * @param string           $src       Full URL of the script, or path of the script relative to the WordPress root directory.
- *                                    Default empty.
- * @param array            $deps      Optional. An array of registered script handles this script depends on. Default empty array.
- * @param string|bool|null $ver       Optional. String specifying script version number, if it has one, which is added to the URL
- *                                    as a query string for cache busting purposes. If version is set to false, a version
- *                                    number is automatically added equal to current installed WordPress version.
- *                                    If set to null, no version is added.
- * @param bool             $in_footer Optional. Whether to enqueue the script before </body> instead of in the <head>.
- *                                    Default 'false'.
- * @return void
- */
-function scaffolding_enqueue_script( $handle, $src = '', $deps = array(), $ver = false, $in_footer = false ) {
-	if ( SCAFFOLDING_USE_JSDELIVR_CDN ) {
-		switch ( $handle ) {
-			case 'scaffolding-retinajs':
-				$src = 'https://cdn.jsdelivr.net/npm/retinajs@' . $ver . '/dist/retina.min.js';
-				break;
-			case 'scaffolding-doubletaptogo-js':
-				$src = 'https://cdn.jsdelivr.net/npm/jquery-doubletaptogo@' . $ver . '/dist/jquery.dcd.doubletaptogo.min.js';
-				break;
-			case 'scaffolding-magnific-popup-js':
-				$src = 'https://cdn.jsdelivr.net/npm/magnific-popup@' . $ver . '/dist/jquery.magnific-popup.min.js';
-				break;
-			case 'scaffolding-selectwoo':
-				$src = 'https://cdn.jsdelivr.net/gh/woocommerce/selectWoo@' . $ver . '/dist/js/selectWoo.full.min.js';
-				break;
-		}
-	}
-	wp_enqueue_script( $handle, $src, $deps, $ver, $in_footer );
-}
 
 
 /************************************

--- a/includes/commonwp.php
+++ b/includes/commonwp.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * CommonWP support
+ *
+ * Adds support for the assets from this package to be loaded through cdn.jsdelivr.net
+ * if you have the commonWP plugin installed https://wordpress.org/plugins/commonwp/
+ *
+ * @package Scaffolding
+ */
+
+/**
+ * Filter scripts and their data available for replacement.
+ *
+ * @param array $scripts Scripts and their data available for replacement.
+ * @return array
+ */
+function scaffolding_commonwp_npm_packages_scripts( $scripts ) {
+	$scripts['scaffolding-retinajs'] = [
+		'package'  => 'retinajs',
+		'file'     => 'dist/retina',
+		'minified' => '.min',
+	];
+	$scripts['scaffolding-doubletaptogo-js'] = [
+		'package'  => 'jquery-doubletaptogo',
+		'file'     => 'dist/jquery.dcd.doubletaptogo',
+		'minified' => '.min',
+	];
+	$scripts['scaffolding-magnific-popup-js'] = [
+		'package'  => 'magnific-popup',
+		'file'     => 'dist/jquery.magnific-popup',
+		'minified' => '.min',
+	];
+	return $scripts;
+}
+add_filter( 'npm_packages_scripts', 'scaffolding_commonwp_npm_packages_scripts', 10, 1 );
+

--- a/libs/js/retina.min.js
+++ b/libs/js/retina.min.js
@@ -1,10 +1,2 @@
-/*!
- * Retina.js v2.1.2 
- *
- * Copyright 2016 Axial, LLC
- * Released under the MIT license
- *
- * Retina.js is an open source script that makes it easy to serve
- * high-resolution images to devices with retina displays.
- */
 (function(a,b){'object'==typeof exports&&'undefined'!=typeof module?module.exports=b():'function'==typeof define&&define.amd?define(b):a.retinajs=b()})(this,function(){'use strict';function a(a){return Array.prototype.slice.call(a)}function b(a){var b=parseInt(a,10);return k<b?k:b}function c(a){return a.hasAttribute('data-no-resize')||(0===a.offsetWidth&&0===a.offsetHeight?(a.setAttribute('width',a.naturalWidth),a.setAttribute('height',a.naturalHeight)):(a.setAttribute('width',a.offsetWidth),a.setAttribute('height',a.offsetHeight))),a}function d(a,b){var d=a.nodeName.toLowerCase(),e=document.createElement('img');e.addEventListener('load',function(){'img'===d?c(a).setAttribute('src',b):a.style.backgroundImage='url('+b+')'}),e.setAttribute('src',b),a.setAttribute(o,!0)}function e(a,c){var e=2<arguments.length&&void 0!==arguments[2]?arguments[2]:1,f=b(e);if(c&&1<f){var g=c.replace(l,'@'+f+'x$1');d(a,g)}}function f(a,b,c){1<k&&d(a,c)}function g(b){return b?'function'==typeof b.forEach?b:a(b):'undefined'==typeof document?[]:a(document.querySelectorAll(n))}function h(a){return a.style.backgroundImage.replace(m,'$2')}function i(a){g(a).forEach(function(a){if(!a.getAttribute(o)){var b='img'===a.nodeName.toLowerCase(),c=b?a.getAttribute('src'):h(a),d=a.getAttribute('data-rjs'),g=!isNaN(parseInt(d,10));if(null===d)return;g?e(a,c,d):f(a,c,d)}})}var j='undefined'!=typeof window,k=Math.round(j?window.devicePixelRatio||1:1),l=/(\.[A-z]{3,4}\/?(\?.*)?)$/,m=/url\(('|")?([^)'"]+)('|")?\)/i,n='[data-rjs]',o='data-rjs-processed';return j&&(window.addEventListener('load',function(){i()}),window.retinajs=i),i});
+//# sourceMappingURL=retina.min.js.map


### PR DESCRIPTION
Remove the `SCAFFOLDING_USE_JSDELIVR_CDN` define and  wrapper scripts to use it.

Instead, add support for the [commonWP](https://wordpress.org/plugins/commonwp/) plugin which makes  the jsdelivr CDN loading simpler and adds extra safety if scripts differ from what is on the CDN.