### PR TITLE
phpcs fixes

### DIFF
--- a/404.php
+++ b/404.php
@@ -7,14 +7,14 @@
 
 get_header();
 
-global $sc_layout_class;
+global $scaffolding_layout_class;
 ?>
 
 <div id="inner-content" class="container">
 
-	<div class="row <?php echo esc_attr( $sc_layout_class['row'] ); ?>">
+	<div class="row <?php echo esc_attr( $scaffolding_layout_class['row'] ); ?>">
 
-		<div id="main" class="<?php echo esc_attr( $sc_layout_class['main'] ); ?> clearfix" role="main">
+		<div id="main" class="<?php echo esc_attr( $scaffolding_layout_class['main'] ); ?> clearfix" role="main">
 
 			<section class="error-404 not-found clearfix">
 

--- a/archive.php
+++ b/archive.php
@@ -11,14 +11,14 @@
 
 get_header();
 
-global $sc_layout_class;
+global $scaffolding_layout_class;
 ?>
 
 <div id="inner-content" class="container">
 
-	<div class="row <?php echo esc_attr( $sc_layout_class['row'] ); ?>">
+	<div class="row <?php echo esc_attr( $scaffolding_layout_class['row'] ); ?>">
 
-		<div id="main" class="<?php echo esc_attr( $sc_layout_class['main'] ); ?> clearfix" role="main">
+		<div id="main" class="<?php echo esc_attr( $scaffolding_layout_class['main'] ); ?> clearfix" role="main">
 
 			<?php
 			if ( have_posts() ) :

--- a/comments.php
+++ b/comments.php
@@ -28,8 +28,8 @@ if ( post_password_required() ) {
 
 		<h3 class="h2 comments-title">
 			<?php
-			$sc_comment_count = get_comments_number();
-			if ( '1' === $sc_comment_count ) {
+			$scaffolding_comment_count = get_comments_number();
+			if ( '1' === $scaffolding_comment_count ) {
 				printf(
 					/* translators: 1: title. */
 					esc_html__( 'One comment on &ldquo;%1$s&rdquo;', 'scaffolding' ),
@@ -38,8 +38,8 @@ if ( post_password_required() ) {
 			} else {
 				printf(
 					/* translators: 1: comment count number, 2: title. */
-					esc_html( _nx( '%1$s comment on &ldquo;%2$s&rdquo;', '%1$s comments on &ldquo;%2$s&rdquo;', $sc_comment_count, 'comments title', 'scaffolding' ) ),
-					number_format_i18n( $sc_comment_count ), // phpcs:ignore
+					esc_html( _nx( '%1$s comment on &ldquo;%2$s&rdquo;', '%1$s comments on &ldquo;%2$s&rdquo;', $scaffolding_comment_count, 'comments title', 'scaffolding' ) ),
+					number_format_i18n( $scaffolding_comment_count ), // phpcs:ignore
 					'<span>' . get_the_title() . '</span>' // phpcs:ignore
 				);
 			}

--- a/front-page.php
+++ b/front-page.php
@@ -12,14 +12,14 @@
 
 get_header();
 
-global $sc_layout_class;
+global $scaffolding_layout_class;
 ?>
 
 <div id="inner-content" class="container">
 
-	<div class="row <?php echo esc_attr( $sc_layout_class['row'] ); ?>">
+	<div class="row <?php echo esc_attr( $scaffolding_layout_class['row'] ); ?>">
 
-		<div id="main" class="<?php echo esc_attr( $sc_layout_class['main'] ); ?> clearfix" role="main">
+		<div id="main" class="<?php echo esc_attr( $scaffolding_layout_class['main'] ); ?> clearfix" role="main">
 
 			<?php
 			if ( have_posts() ) :

--- a/functions.php
+++ b/functions.php
@@ -671,14 +671,14 @@ function scaffolding_set_layout_classes( $type ) {
  */
 function scaffolding_layout_classes_globals() {
 	if ( function_exists( 'scaffolding_set_layout_classes' ) ) {
-		$GLOBALS['sc_sidebar_class'] = scaffolding_set_layout_classes( 'sidebar' );
-		$GLOBALS['sc_layout_class']  = scaffolding_set_layout_classes( 'content' );
+		$GLOBALS['scaffolding_sidebar_class'] = scaffolding_set_layout_classes( 'sidebar' );
+		$GLOBALS['scaffolding_layout_class']  = scaffolding_set_layout_classes( 'content' );
 	} else {
-		$GLOBALS['sc_sidebar_class'] = array(
+		$GLOBALS['scaffolding_sidebar_class'] = array(
 			'left'  => '',
 			'right' => '',
 		);
-		$GLOBALS['sc_layout_class']  = array(
+		$GLOBALS['scaffolding_layout_class']  = array(
 			'row'  => 'row-main no-sidebars',
 			'main' => 'col-12',
 		);

--- a/functions.php
+++ b/functions.php
@@ -51,7 +51,7 @@ require_once SCAFFOLDING_INCLUDE_PATH . 'tinymce-settings.php';
 if ( class_exists( 'GFForms' ) ) {
 	require_once SCAFFOLDING_INCLUDE_PATH . 'gf-customizations.php';
 }
-// commonWP Support https://wordpress.org/plugins/commonwp/
+// commonWP Support https://wordpress.org/plugins/commonwp/ for details.
 require_once SCAFFOLDING_INCLUDE_PATH . 'commonwp.php';
 
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,9 @@
+/**
+ * Name: Gulpfile
+ *
+ * @package scaffolding
+ */
+
 // Require Libraries.
 var gulp        = require( 'gulp' ),
 	path        = require( 'path' ),

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,9 +1,9 @@
 // Require Libraries.
-var gulp = require( 'gulp' ),
-	path = require( 'path' ),
-	compass = require( 'gulp-compass' ),
-	browserSync = require('browser-sync');
-	WP = require( 'wp-cli' );
+var gulp        = require( 'gulp' ),
+	path        = require( 'path' ),
+	compass     = require( 'gulp-compass' ),
+	browserSync = require( 'browser-sync' );
+	WP          = require( 'wp-cli' );
 
 // Current Working Directory.
 var cwd = process.env.INIT_CWD;
@@ -29,49 +29,73 @@ var assets = {
 	js: [paths.js + '**/*'],
 };
 
-gulp.task('serve', function() {
+gulp.task(
+	'serve',
+	function() {
 
-	WP.discover( {path:'../../../'}, function( WP ) {
-		WP.option.get( ['siteurl'], function( err,result ){
+		WP.discover(
+			{path:'../../../'},
+			function( WP ) {
+				WP.option.get(
+					['siteurl'],
+					function( err,result ){
 
-			siteurl = result;
+						siteurl = result;
 
-			browserSync.init({
-				proxy: siteurl,
-				ghostMode: {
-					clicks: true,
-					forms: true,
-					scroll: true
-				}
-			});
+						browserSync.init(
+							{
+								proxy: siteurl,
+								ghostMode: {
+									clicks: true,
+									forms: true,
+									scroll: true
+								}
+							}
+						);
 
-			gulp.watch( cwd + '/**/*.php', ['browsersync']);
-		});
-	});
-});
+						gulp.watch( cwd + '/**/*.php', ['browsersync'] );
+					}
+				);
+			}
+		);
+	}
+);
 
 // Compass Task.
-gulp.task( 'compass', function () {
-	gulp.src( paths.sass )
-		.pipe( compass( {
-			config_file: cwd + '/scss/config.rb',
-			css: paths.css,
-			sass: paths.sass
-		}));
-});
+gulp.task(
+	'compass',
+	function () {
+		gulp.src( paths.sass )
+		.pipe(
+			compass(
+				{
+					config_file: cwd + '/scss/config.rb',
+					css: paths.css,
+					sass: paths.sass
+				}
+			)
+		);
+	}
+);
 
 // Watch Task.
-gulp.task( 'watch', function () {
-	gulp.watch( assets.sass, ['compass'] );
-	gulp.watch( assets.css, ['browsersync'] );
-	gulp.watch( assets.js, ['browsersync'] );
-	gulp.watch( cwd + '**/*.php', ['browsersync'] );
-});
+gulp.task(
+	'watch',
+	function () {
+		gulp.watch( assets.sass, ['compass'] );
+		gulp.watch( assets.css, ['browsersync'] );
+		gulp.watch( assets.js, ['browsersync'] );
+		gulp.watch( cwd + '**/*.php', ['browsersync'] );
+	}
+);
 
 // CSS Reload.
-gulp.task( 'browsersync', function () {
-	browserSync.reload();
-});
+gulp.task(
+	'browsersync',
+	function () {
+		browserSync.reload();
+	}
+);
 
 // Default.
 gulp.task( 'default', ['serve', 'compass', 'watch'] );

--- a/home.php
+++ b/home.php
@@ -11,14 +11,14 @@
 
 get_header();
 
-global $sc_layout_class;
+global $scaffolding_layout_class;
 ?>
 
 <div id="inner-content" class="container">
 
-	<div class="row <?php echo esc_attr( $sc_layout_class['row'] ); ?>">
+	<div class="row <?php echo esc_attr( $scaffolding_layout_class['row'] ); ?>">
 
-		<div id="main" class="<?php echo esc_attr( $sc_layout_class['main'] ); ?> clearfix" role="main">
+		<div id="main" class="<?php echo esc_attr( $scaffolding_layout_class['main'] ); ?> clearfix" role="main">
 
 			<?php
 			if ( have_posts() ) :

--- a/includes/base-functions.php
+++ b/includes/base-functions.php
@@ -64,6 +64,7 @@ add_action( 'after_setup_theme', 'scaffolding_build', 16 );
  * @since Scaffolding 1.0
  */
 function scaffolding_head_cleanup() {
+	// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
 	// remove_action( 'wp_head', 'feed_links_extra', 3 );                 // category feeds.
 	// remove_action( 'wp_head', 'feed_links', 2 );                       // post and comment feeds.
 	remove_action( 'wp_head', 'rsd_link' );                               // EditURI link.

--- a/includes/class-scaffolding-walker-nav-menu.php
+++ b/includes/class-scaffolding-walker-nav-menu.php
@@ -24,7 +24,7 @@ class Scaffolding_Walker_Nav_Menu extends Walker_Nav_Menu {
 	 * @param int      $depth  Depth of menu item. Used for padding.
 	 * @param stdClass $args   An object of wp_nav_menu() arguments.
 	 */
-	public function start_lvl( &$output, $depth = 0, $args = array() ) {
+	public function start_lvl( &$output, $depth = 0, $args = array() ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassAfterLastUsed
 		// depth dependent classes.
 		$indent        = ( $depth > 0 ? str_repeat( "\t", $depth ) : '' ); // code indent.
 		$display_depth = ( $depth + 1 ); // because it counts the first submenu as 0.
@@ -61,11 +61,11 @@ class Scaffolding_Walker_Nav_Menu extends Walker_Nav_Menu {
 		}
 
 		// combine the class array into a string.
-		$class_names = join( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args ) );
+		$class_names = join( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$class_names = ' class="' . esc_attr( $class_names ) . '"';
 
 		// set li id.
-		$id = apply_filters( 'nav_menu_item_id', 'menu-item-' . $item->ID, $item, $args );
+		$id = apply_filters( 'nav_menu_item_id', 'menu-item-' . $item->ID, $item, $args ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$id = strlen( $id ) ? ' id="' . esc_attr( $id ) . '"' : '';
 
 		// set outer li and its attributes.
@@ -86,11 +86,11 @@ class Scaffolding_Walker_Nav_Menu extends Walker_Nav_Menu {
 
 		$item_output  = $args->before;
 		$item_output .= '<a' . $attributes . '>';
-		$item_output .= $args->link_before . apply_filters( 'the_title', $item->title, $item->ID ) . $args->link_after;
+		$item_output .= $args->link_before . apply_filters( 'the_title', $item->title, $item->ID ) . $args->link_after; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$item_output .= '</a>';
 		$item_output .= $menu_pull_link . $args->after;
 
-		$output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
+		$output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 	}
 
 	/**
@@ -103,7 +103,7 @@ class Scaffolding_Walker_Nav_Menu extends Walker_Nav_Menu {
 	 * @param int      $depth  Depth of page. Not Used.
 	 * @param stdClass $args   An object of wp_nav_menu() arguments.
 	 */
-	public function end_el( &$output, $item, $depth = 0, $args = array() ) {
+	public function end_el( &$output, $item, $depth = 0, $args = array() ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassAfterLastUsed
 		$output .= "</li>\n";
 	}
 

--- a/includes/commonwp.php
+++ b/includes/commonwp.php
@@ -15,21 +15,21 @@
  * @return array
  */
 function scaffolding_commonwp_npm_packages_scripts( $scripts ) {
-	$scripts['scaffolding-retinajs'] = [
+	$scripts['scaffolding-retinajs']          = array(
 		'package'  => 'retinajs',
 		'file'     => 'dist/retina',
 		'minified' => '.min',
-	];
-	$scripts['scaffolding-doubletaptogo-js'] = [
+	);
+	$scripts['scaffolding-doubletaptogo-js']  = array(
 		'package'  => 'jquery-doubletaptogo',
 		'file'     => 'dist/jquery.dcd.doubletaptogo',
 		'minified' => '.min',
-	];
-	$scripts['scaffolding-magnific-popup-js'] = [
+	);
+	$scripts['scaffolding-magnific-popup-js'] = array(
 		'package'  => 'magnific-popup',
 		'file'     => 'dist/jquery.magnific-popup',
 		'minified' => '.min',
-	];
+	);
 	return $scripts;
 }
 add_filter( 'npm_packages_scripts', 'scaffolding_commonwp_npm_packages_scripts', 10, 1 );

--- a/includes/tinymce-settings.php
+++ b/includes/tinymce-settings.php
@@ -15,10 +15,9 @@
  * TinyMCE: First line toolbar customizations
  * There are 4 total lines that may be added
  *
- * @param array $buttons Buttons that are enabled for line 1.
  * @return array Buttons that are enabled for line 1.
  */
-function scaffolding_tinymce_modify_mce_buttons_1( $buttons ) {
+function scaffolding_tinymce_modify_mce_buttons_1() {
 	// The settings are returned in this array. Customize to suite your needs.
 	return array(
 		'bold',
@@ -39,8 +38,8 @@ function scaffolding_tinymce_modify_mce_buttons_1( $buttons ) {
 		'wp_adv',
 	);
 
-	/*
-	// WordPress Default
+	/* phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+	WordPress Default
 	return array(
 		'bold', 'italic', 'strikethrough', bullist', 'numlist', 'blockquote', 'hr',
 		'alignleft', 'aligncenter', 'alignright', 'link', 'unlink', 'wp_more',
@@ -48,16 +47,15 @@ function scaffolding_tinymce_modify_mce_buttons_1( $buttons ) {
 	);
 	*/
 }
-add_filter( 'mce_buttons', 'scaffolding_tinymce_modify_mce_buttons_1', 0 );
+add_filter( 'mce_buttons', 'scaffolding_tinymce_modify_mce_buttons_1', 0, 0 );
 
 /**
  * TinyMCE: Second line toolbar customizations
  * There are 4 total lines that may be added
  *
- * @param array $buttons Buttons that are enabled for line 2.
  * @return array Buttons that are enabled for line 2
  */
-function scaffolding_tinymce_modify_mce_buttons_2( $buttons ) {
+function scaffolding_tinymce_modify_mce_buttons_2() {
 	// The settings are returned in this array. Customize to suite your needs.
 	return array(
 		'styleselect',
@@ -76,15 +74,15 @@ function scaffolding_tinymce_modify_mce_buttons_2( $buttons ) {
 		'wp_help',
 	);
 
-	/*
-	WordPress Default
+	/* phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+	WordPress Default.
 	return array(
 		'formatselect', 'underline', 'alignfull', 'pastetext', 'pasteword', 'removeformat', 'charmap',
 		'outdent', 'indent', 'undo', 'redo', 'wp_help'
 	);
 	*/
 }
-add_filter( 'mce_buttons_2', 'scaffolding_tinymce_modify_mce_buttons_2', 0 );
+add_filter( 'mce_buttons_2', 'scaffolding_tinymce_modify_mce_buttons_2', 0, 0 );
 
 /**
  * TinyMCE: Modify 'styleselect'
@@ -200,9 +198,9 @@ function scaffolding_tinymce_modify_styleselect( $settings ) {
 					'icon'   => 'alignright',
 				),
 				array(
-					'title'   => 'Justify',
-					'format'  => 'alignjustify',
-					'icon'    => 'alignjustify',
+					'title'  => 'Justify',
+					'format' => 'alignjustify',
+					'icon'   => 'alignjustify',
 				),
 			),
 		),

--- a/index.php
+++ b/index.php
@@ -11,14 +11,14 @@
 
 get_header();
 
-global $sc_layout_class;
+global $scaffolding_layout_class;
 ?>
 
 <div id="inner-content" class="container">
 
-	<div class="row <?php echo esc_attr( $sc_layout_class['row'] ); ?>">
+	<div class="row <?php echo esc_attr( $scaffolding_layout_class['row'] ); ?>">
 
-		<div id="main" class="<?php echo esc_attr( $sc_layout_class['main'] ); ?> clearfix" role="main">
+		<div id="main" class="<?php echo esc_attr( $scaffolding_layout_class['main'] ); ?> clearfix" role="main">
 
 			<?php
 			if ( have_posts() ) :

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -3,58 +3,75 @@ Site Name:
 Author:
 
 Name: Navigation Scripts
-
-******************************************************************/
+ ******************************************************************/
 
 // as the page loads, call these scripts
-jQuery(document).ready(function($) {
+jQuery( document ).ready(
+	function($) {
 
-	// getting viewport width
-	var responsive_viewport = $(window).width() + getScrollBarWidth();
-
-	/*
-	Mobile Navigation
-	*/
-	$(function() {
-		$('#mobile-menu-button').on('click', function(e) {
-			if ( ! $('body').hasClass('menu-open') ) {
-				$('#main-navigation > ul.main-menu').css('display','block');
-				$('body').toggleClass('menu-open');
-			} else {
-				$('body').toggleClass('menu-open');
-				setTimeout( function(){
-					$('#main-navigation > ul.main-menu').css('display','none');
-				},500);
-			}
-		});
-
-		$('#main-navigation .menu-item > .menu-button').on('click', function(e) {
-			$(this).next('.sub-menu').addClass('sub-menu-open');
-		});
-
-		$('#main-navigation .sub-menu .menu-back-button').on('click', function(e) {
-			$(this).parent('li').parent('ul').removeClass('sub-menu-open');
-		});
+		// getting viewport width
+		var responsive_viewport = $( window ).width() + getScrollBarWidth();
 
 		/*
-		Fixes bug on touch devices
-		opens ul on first tap
-		accepts anchor and opens page on second tap
+		Mobile Navigation
 		*/
-		if ($.fn.doubleTapToGo) {
-			responsive_viewport = $(window).width() + getScrollBarWidth();
-			if (responsive_viewport >= 768) {
-				$('#main-navigation').doubleTapToGo();
+		$(
+			function() {
+				$( '#mobile-menu-button' ).on(
+					'click',
+					function(e) {
+						if ( ! $( 'body' ).hasClass( 'menu-open' ) ) {
+							$( '#main-navigation > ul.main-menu' ).css( 'display','block' );
+							$( 'body' ).toggleClass( 'menu-open' );
+						} else {
+							$( 'body' ).toggleClass( 'menu-open' );
+							setTimeout(
+								function(){
+									$( '#main-navigation > ul.main-menu' ).css( 'display','none' );
+								},
+								500
+							);
+						}
+					}
+				);
+
+				$( '#main-navigation .menu-item > .menu-button' ).on(
+					'click',
+					function(e) {
+						$( this ).next( '.sub-menu' ).addClass( 'sub-menu-open' );
+					}
+				);
+
+				$( '#main-navigation .sub-menu .menu-back-button' ).on(
+					'click',
+					function(e) {
+						$( this ).parent( 'li' ).parent( 'ul' ).removeClass( 'sub-menu-open' );
+					}
+				);
+
+				/*
+				Fixes bug on touch devices
+				opens ul on first tap
+				accepts anchor and opens page on second tap
+				*/
+				if ($.fn.doubleTapToGo) {
+					responsive_viewport = $( window ).width() + getScrollBarWidth();
+					if (responsive_viewport >= 768) {
+						$( '#main-navigation' ).doubleTapToGo();
+					}
+				}
 			}
-		}
-	});
+		);
 
-	$(window).resize(function(e) {
-		responsive_viewport = $(window).width() + getScrollBarWidth();
-		if (responsive_viewport >= 768) {
-			$('body').removeClass('menu-open');
-			$('#main-navigation > ul.main-menu').removeAttr('style');
-		}
-	});
+		$( window ).resize(
+			function(e) {
+				responsive_viewport = $( window ).width() + getScrollBarWidth();
+				if (responsive_viewport >= 768) {
+					$( 'body' ).removeClass( 'menu-open' );
+					$( '#main-navigation > ul.main-menu' ).removeAttr( 'style' );
+				}
+			}
+		);
 
-});
+	}
+);

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -1,15 +1,17 @@
-/******************************************************************
-Site Name:
-Author:
+/**
+ * Site Name:
+ * Author:
+ *
+ * Name: Navigation Scripts
+ *
+ * @package scaffolding
+ */
 
-Name: Navigation Scripts
- ******************************************************************/
-
-// as the page loads, call these scripts
+// as the page loads, call these scripts.
 jQuery( document ).ready(
 	function($) {
 
-		// getting viewport width
+		// getting viewport width.
 		var responsive_viewport = $( window ).width() + getScrollBarWidth();
 
 		/*

--- a/js/responsive-iframes.js
+++ b/js/responsive-iframes.js
@@ -1,29 +1,37 @@
 (function($){
 
-	jQuery(document).ready(function($) {
+	jQuery( document ).ready(
+		function($) {
 
-		// Responsive iFrames, Embeds and Objects - http://css-tricks.com/NetMag/FluidWidthVideo/Article-FluidWidthVideo.php
-		// Fallback for elements outside the Gutenberg blocks (ie. using the Classic Editor)
-		var $allVideos = $(":not(.wp-block-embed__wrapper) > iframe[src*='youtube'], :not(.wp-block-embed__wrapper) > iframe[src*='vimeo'], :not(.wp-block-embed__wrapper) > iframe[src*='dailymotion'], :not(.wp-block-embed__wrapper) > iframe[src*='funnyordie'], :not(.wp-block-embed__wrapper) > object, :not(.wp-block-embed__wrapper) > embed").wrap( "<figure></figure>" );
+			// Responsive iFrames, Embeds and Objects - http://css-tricks.com/NetMag/FluidWidthVideo/Article-FluidWidthVideo.php
+			// Fallback for elements outside the Gutenberg blocks (ie. using the Classic Editor)
+			var $allVideos = $( ":not(.wp-block-embed__wrapper) > iframe[src*='youtube'], :not(.wp-block-embed__wrapper) > iframe[src*='vimeo'], :not(.wp-block-embed__wrapper) > iframe[src*='dailymotion'], :not(.wp-block-embed__wrapper) > iframe[src*='funnyordie'], :not(.wp-block-embed__wrapper) > object, :not(.wp-block-embed__wrapper) > embed" ).wrap( "<figure></figure>" );
 
-		$allVideos.each(function() {
-			$(this)
-			// jQuery .data does not work on object/embed elements
-			.attr('data-aspectRatio', this.height / this.width)
-			.css({ 'max-width': this.width + 'px', 'max-height': this.height + 'px' })
-			.removeAttr('height')
-			.removeAttr('width');
-		});
-		$(window).resize(function() {
-			$allVideos.each(function() {
-				var $el = $(this);
-				var newWidth = $el.closest('figure').width();
-				$el
-				.width(newWidth)
-				.height(newWidth * $el.attr('data-aspectRatio'));
-			});
-		}).resize();
+			$allVideos.each(
+				function() {
+					$( this )
+					// jQuery .data does not work on object/embed elements
+					.attr( 'data-aspectRatio', this.height / this.width )
+					.css( { 'max-width': this.width + 'px', 'max-height': this.height + 'px' } )
+					.removeAttr( 'height' )
+					.removeAttr( 'width' );
+				}
+			);
+			$( window ).resize(
+				function() {
+					$allVideos.each(
+						function() {
+							var $el      = $( this );
+							var newWidth = $el.closest( 'figure' ).width();
+							$el
+							.width( newWidth )
+							.height( newWidth * $el.attr( 'data-aspectRatio' ) );
+						}
+					);
+				}
+			).resize();
 
-	});
+		}
+	);
 
-})(jQuery);
+})( jQuery );

--- a/js/responsive-iframes.js
+++ b/js/responsive-iframes.js
@@ -1,16 +1,25 @@
+/**
+ * Site Name:
+ * Author:
+ *
+ * Name: Responsive iFrames
+ *
+ * @package scaffolding
+ */
+
 (function($){
 
 	jQuery( document ).ready(
 		function($) {
 
-			// Responsive iFrames, Embeds and Objects - http://css-tricks.com/NetMag/FluidWidthVideo/Article-FluidWidthVideo.php
-			// Fallback for elements outside the Gutenberg blocks (ie. using the Classic Editor)
+			// Responsive iFrames, Embeds and Objects - http://css-tricks.com/NetMag/FluidWidthVideo/Article-FluidWidthVideo.php .
+			// Fallback for elements outside the Gutenberg blocks (ie. using the Classic Editor).
 			var $allVideos = $( ":not(.wp-block-embed__wrapper) > iframe[src*='youtube'], :not(.wp-block-embed__wrapper) > iframe[src*='vimeo'], :not(.wp-block-embed__wrapper) > iframe[src*='dailymotion'], :not(.wp-block-embed__wrapper) > iframe[src*='funnyordie'], :not(.wp-block-embed__wrapper) > object, :not(.wp-block-embed__wrapper) > embed" ).wrap( "<figure></figure>" );
 
 			$allVideos.each(
 				function() {
 					$( this )
-					// jQuery .data does not work on object/embed elements
+					// jQuery .data does not work on object/embed elements.
 					.attr( 'data-aspectRatio', this.height / this.width )
 					.css( { 'max-width': this.width + 'px', 'max-height': this.height + 'px' } )
 					.removeAttr( 'height' )

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -8,112 +8,133 @@ This file should contain any js scripts you want to add to the site.
 Instead of calling it in the header or throwing it inside wp_head()
 this file will be called automatically in the footer so as not to
 slow the page load.
-
-******************************************************************/
+ ******************************************************************/
 
 // Calculate the width of the scroll bar so css media queries and js widow.width match
 function getScrollBarWidth () {
-	var inner = document.createElement('p');
-	inner.style.width = "100%";
+	var inner          = document.createElement( 'p' );
+	inner.style.width  = "100%";
 	inner.style.height = "200px";
 
-	var outer = document.createElement('div');
-	outer.style.position = "absolute";
-	outer.style.top = "0px";
-	outer.style.left = "0px";
+	var outer              = document.createElement( 'div' );
+	outer.style.position   = "absolute";
+	outer.style.top        = "0px";
+	outer.style.left       = "0px";
 	outer.style.visibility = "hidden";
-	outer.style.width = "200px";
-	outer.style.height = "150px";
-	outer.style.overflow = "hidden";
-	outer.appendChild (inner);
+	outer.style.width      = "200px";
+	outer.style.height     = "150px";
+	outer.style.overflow   = "hidden";
+	outer.appendChild( inner );
 
-	document.body.appendChild (outer);
-	var w1 = inner.offsetWidth;
+	document.body.appendChild( outer );
+	var w1               = inner.offsetWidth;
 	outer.style.overflow = 'scroll';
-	var w2 = inner.offsetWidth;
-	if (w1 == w2) w2 = outer.clientWidth;
+	var w2               = inner.offsetWidth;
+	if (w1 == w2) {
+		w2 = outer.clientWidth;
+	}
 
-	document.body.removeChild (outer);
+	document.body.removeChild( outer );
 
 	return (w1 - w2);
 };
 
 // As the page loads, call these scripts
-jQuery(document).ready(function($) {
+jQuery( document ).ready(
+	function($) {
 
-	// Initialize Retinajs - https://github.com/strues/retinajs
-	if (jQuery.fn.retinajs) {
-		retinajs();
-	}
+		// Initialize Retinajs - https://github.com/strues/retinajs
+		if (jQuery.fn.retinajs) {
+			retinajs();
+		}
 
-	// SelectWoo - https://github.com/woocommerce/selectWoo
-	if ($.fn.selectWoo) {
-		var setup_selectWoo = function() {
-			$('select').each(function(){
-				$(this).selectWoo({
-					minimumResultsForSearch: 20,
-					width: 'null',
-				});
-			});
-		};
-		$(document).ajaxComplete(setup_selectWoo);
-		$(document).bind('gform_post_render', setup_selectWoo);
-		setup_selectWoo();
-	}
+		// SelectWoo - https://github.com/woocommerce/selectWoo
+		if ($.fn.selectWoo) {
+			var setup_selectWoo = function() {
+				$( 'select' ).each(
+					function(){
+						$( this ).selectWoo(
+							{
+								minimumResultsForSearch: 20,
+								width: 'null',
+							}
+						);
+					}
+				);
+			};
+			$( document ).ajaxComplete( setup_selectWoo );
+			$( document ).bind( 'gform_post_render', setup_selectWoo );
+			setup_selectWoo();
+		}
 
-	// Lightbox - http://dimsemenov.com/plugins/magnific-popup/
-	if ($.fn.magnificPopup) {
-		$image_selector = 'a[href$=".jpg"], a[href$=".jpeg"], a[href$=".png"], a[href$=".gif"]';
+		// Lightbox - http://dimsemenov.com/plugins/magnific-popup/
+		if ($.fn.magnificPopup) {
+			$image_selector = 'a[href$=".jpg"], a[href$=".jpeg"], a[href$=".png"], a[href$=".gif"]';
 
-		// single image popup
-		$($image_selector).each(function(){
-			if ($(this).parents('.gallery').length == 0) {
-				$(this).magnificPopup({type:'image'});
-			}
-		});
-
-		// gallery popup
-		$('.gallery').each(function() {
-			$(this).magnificPopup({
-				type: 'image',
-				delegate: $image_selector,
-				gallery: {
-					enabled: true,
-					preload: [1,2]
-				},
-				image: {
-					titleSrc: function(item) {
-						return item.el.parents('.gallery-item').find('.gallery-caption').text();
+			// single image popup
+			$( $image_selector ).each(
+				function(){
+					if ($( this ).parents( '.gallery' ).length == 0) {
+						$( this ).magnificPopup( {type:'image'} );
 					}
 				}
-			});
-		});
+			);
+
+			// gallery popup
+			$( '.gallery' ).each(
+				function() {
+					$( this ).magnificPopup(
+						{
+							type: 'image',
+							delegate: $image_selector,
+							gallery: {
+								enabled: true,
+								preload: [1,2]
+							},
+							image: {
+								titleSrc: function(item) {
+									return item.el.parents( '.gallery-item' ).find( '.gallery-caption' ).text();
+								}
+							}
+						}
+					);
+				}
+			);
+		}
+
+		// hide #back-top first
+		$( "#back-top" ).hide();
+
+		// fade in #back-top
+		$(
+			function () {
+				$( window ).scroll(
+					function () {
+						if ($( this ).scrollTop() > 300) {
+							$( '#back-top' ).fadeIn();
+						} else {
+							$( '#back-top' ).fadeOut();
+						}
+					}
+				);
+
+				// scroll body to 0px on click
+				$( '#back-top a' ).click(
+					function () {
+						$( 'body,html' ).animate(
+							{
+								scrollTop: 0
+							},
+							800
+						);
+						return false;
+					}
+				);
+			}
+		);
+
 	}
-
-	// hide #back-top first
-	$("#back-top").hide();
-
-	// fade in #back-top
-	$(function () {
-		$(window).scroll(function () {
-			if ($(this).scrollTop() > 300) {
-				$('#back-top').fadeIn();
-			}
-			else {
-				$('#back-top').fadeOut();
-			}
-		});
-
-		// scroll body to 0px on click
-		$('#back-top a').click(function () {
-			$('body,html').animate({
-				scrollTop: 0
-			}, 800);
-			return false;
-		});
-	});
-
-}); /* end of as page load scripts */
+); /* end of as page load scripts */
 
 /*! A fix for the iOS orientationchange zoom bug.
  Script by @scottjehl, rebound by @wilto.
@@ -121,20 +142,20 @@ jQuery(document).ready(function($) {
 */
 (function(w){
 	// This fix addresses an iOS bug, so return early if the UA claims it's something else.
-	if( !( /iPhone|iPad|iPod/.test( navigator.platform ) && navigator.userAgent.indexOf( "AppleWebKit" ) > -1 ) ) {
+	if ( ! ( /iPhone|iPad|iPod/.test( navigator.platform ) && navigator.userAgent.indexOf( "AppleWebKit" ) > -1 ) ) {
 		return;
 	}
 	var doc = w.document;
-	if( !doc.querySelector ) {
+	if ( ! doc.querySelector ) {
 		return;
 	}
-	var meta = doc.querySelector( "meta[name=viewport]" ),
+	var meta           = doc.querySelector( "meta[name=viewport]" ),
 		initialContent = meta && meta.getAttribute( "content" ),
-		disabledZoom = initialContent + ",maximum-scale=1",
-		enabledZoom = initialContent + ",maximum-scale=10",
-		enabled = true,
+		disabledZoom   = initialContent + ",maximum-scale=1",
+		enabledZoom    = initialContent + ",maximum-scale=10",
+		enabled        = true,
 		x, y, z, aig;
-	if( !meta ) {
+	if ( ! meta ) {
 		return;
 	}
 	function restoreZoom() {
@@ -147,16 +168,15 @@ jQuery(document).ready(function($) {
 	}
 	function checkTilt( e ) {
 		aig = e.accelerationIncludingGravity;
-		x = Math.abs( aig.x );
-		y = Math.abs( aig.y );
-		z = Math.abs( aig.z );
+		x   = Math.abs( aig.x );
+		y   = Math.abs( aig.y );
+		z   = Math.abs( aig.z );
 		// If portrait orientation and in one of the danger zones
-		if( !w.orientation && ( x > 7 || ( ( z > 6 && y < 8 || z < 8 && y > 6 ) && x > 5 ) ) ) {
-			if( enabled ){
+		if ( ! w.orientation && ( x > 7 || ( ( z > 6 && y < 8 || z < 8 && y > 6 ) && x > 5 ) ) ) {
+			if ( enabled ) {
 				disableZoom();
 			}
-		}
-		else if( !enabled ) {
+		} else if ( ! enabled ) {
 			restoreZoom();
 		}
 	}

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -1,16 +1,18 @@
-/******************************************************************
-Site Name:
-Author:
+/**
+ * Site Name:
+ * Author:
+ *
+ * Name: Scaffolding Scripts
+ *
+ * @package scaffolding
+ *
+ * This file should contain any js scripts you want to add to the site.
+ * Instead of calling it in the header or throwing it inside wp_head()
+ * this file will be called automatically in the footer so as not to
+ * slow the page load.
+ */
 
-Name: Scaffolding Scripts
-
-This file should contain any js scripts you want to add to the site.
-Instead of calling it in the header or throwing it inside wp_head()
-this file will be called automatically in the footer so as not to
-slow the page load.
- ******************************************************************/
-
-// Calculate the width of the scroll bar so css media queries and js widow.width match
+// Calculate the width of the scroll bar so css media queries and js widow.width match.
 function getScrollBarWidth () {
 	var inner          = document.createElement( 'p' );
 	inner.style.width  = "100%";
@@ -39,16 +41,16 @@ function getScrollBarWidth () {
 	return (w1 - w2);
 };
 
-// As the page loads, call these scripts
+// As the page loads, call these scripts.
 jQuery( document ).ready(
 	function($) {
 
-		// Initialize Retinajs - https://github.com/strues/retinajs
+		// Initialize Retinajs - https://github.com/strues/retinajs .
 		if (jQuery.fn.retinajs) {
 			retinajs();
 		}
 
-		// SelectWoo - https://github.com/woocommerce/selectWoo
+		// SelectWoo - https://github.com/woocommerce/selectWoo .
 		if ($.fn.selectWoo) {
 			var setup_selectWoo = function() {
 				$( 'select' ).each(
@@ -67,11 +69,11 @@ jQuery( document ).ready(
 			setup_selectWoo();
 		}
 
-		// Lightbox - http://dimsemenov.com/plugins/magnific-popup/
+		// Lightbox - http://dimsemenov.com/plugins/magnific-popup/ .
 		if ($.fn.magnificPopup) {
 			$image_selector = 'a[href$=".jpg"], a[href$=".jpeg"], a[href$=".png"], a[href$=".gif"]';
 
-			// single image popup
+			// single image popup.
 			$( $image_selector ).each(
 				function(){
 					if ($( this ).parents( '.gallery' ).length == 0) {
@@ -80,7 +82,7 @@ jQuery( document ).ready(
 				}
 			);
 
-			// gallery popup
+			// gallery popup.
 			$( '.gallery' ).each(
 				function() {
 					$( this ).magnificPopup(
@@ -102,10 +104,10 @@ jQuery( document ).ready(
 			);
 		}
 
-		// hide #back-top first
+		// hide #back-top first.
 		$( "#back-top" ).hide();
 
-		// fade in #back-top
+		// fade in #back-top.
 		$(
 			function () {
 				$( window ).scroll(
@@ -118,7 +120,7 @@ jQuery( document ).ready(
 					}
 				);
 
-				// scroll body to 0px on click
+				// scroll body to 0px on click.
 				$( '#back-top a' ).click(
 					function () {
 						$( 'body,html' ).animate(
@@ -136,10 +138,11 @@ jQuery( document ).ready(
 	}
 ); /* end of as page load scripts */
 
-/*! A fix for the iOS orientationchange zoom bug.
- Script by @scottjehl, rebound by @wilto.
- MIT License.
-*/
+/*!
+ * A fix for the iOS orientationchange zoom bug.
+ * Script by @scottjehl, rebound by @wilto.
+ * MIT License.
+ */
 (function(w){
 	// This fix addresses an iOS bug, so return early if the UA claims it's something else.
 	if ( ! ( /iPhone|iPad|iPod/.test( navigator.platform ) && navigator.userAgent.indexOf( "AppleWebKit" ) > -1 ) ) {
@@ -171,7 +174,7 @@ jQuery( document ).ready(
 		x   = Math.abs( aig.x );
 		y   = Math.abs( aig.y );
 		z   = Math.abs( aig.z );
-		// If portrait orientation and in one of the danger zones
+		// If portrait orientation and in one of the danger zones.
 		if ( ! w.orientation && ( x > 7 || ( ( z > 6 && y < 8 || z < 8 && y > 6 ) && x > 5 ) ) ) {
 			if ( enabled ) {
 				disableZoom();

--- a/page.php
+++ b/page.php
@@ -9,14 +9,14 @@
 
 get_header();
 
-global $sc_layout_class;
+global $scaffolding_layout_class;
 ?>
 
 <div id="inner-content" class="container">
 
-	<div class="row <?php echo esc_attr( $sc_layout_class['row'] ); ?>">
+	<div class="row <?php echo esc_attr( $scaffolding_layout_class['row'] ); ?>">
 
-		<div id="main" class="<?php echo esc_attr( $sc_layout_class['main'] ); ?> clearfix" role="main">
+		<div id="main" class="<?php echo esc_attr( $scaffolding_layout_class['main'] ); ?> clearfix" role="main">
 
 			<?php
 			if ( have_posts() ) :

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,6 +3,8 @@
 
 	<description>>A custom set of code standard rules to check for WordPress themes.</description>
 
+	<files>.</files>
+
 	<!-- Exclude the Composer Vendor directory. -->
 	<exclude-pattern>/vendor/*</exclude-pattern>
 
@@ -11,6 +13,12 @@
 
 	<!-- Exclude minified Javascript files. -->
 	<exclude-pattern>*.min.js</exclude-pattern>
+
+	<!-- Exclude Compiled css files. -->
+	<exclude-pattern>/css/*</exclude-pattern>
+
+	<!-- Exclude third party libraries. -->
+	<exclude-pattern>/libs/*</exclude-pattern>
 
 	<!-- Include the WordPress-Extra standard. -->
 	<rule ref="WordPress-Extra">

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -69,7 +69,6 @@
 		<properties>
 			<property name="prefixes" type="array">
 				<element value="scaffolding"/>
-				<element value="sc"/>
 			</property>
 		</properties>
 	</rule>

--- a/search.php
+++ b/search.php
@@ -9,14 +9,14 @@
 
 get_header();
 
-global $sc_layout_class;
+global $scaffolding_layout_class;
 ?>
 
 <div id="inner-content" class="container">
 
-	<div class="row <?php echo esc_attr( $sc_layout_class['row'] ); ?>">
+	<div class="row <?php echo esc_attr( $scaffolding_layout_class['row'] ); ?>">
 
-		<div id="main" class="<?php echo esc_attr( $sc_layout_class['main'] ); ?> clearfix" role="main">
+		<div id="main" class="<?php echo esc_attr( $scaffolding_layout_class['main'] ); ?> clearfix" role="main">
 
 			<div itemscope itemtype="http://schema.org/SearchResultsPage">
 

--- a/searchform.php
+++ b/searchform.php
@@ -5,17 +5,17 @@
  * @package Scaffolding
  */
 
-global $sc_search_form_index;
+global $scaffolding_search_form_index;
 
-if ( empty( $sc_search_form_index ) ) {
-	$sc_search_form_index = 0;
+if ( empty( $scaffolding_search_form_index ) ) {
+	$scaffolding_search_form_index = 0;
 }
 
-$sc_index = $sc_search_form_index++;
+$scaffolding_index = $scaffolding_search_form_index++;
 
 ?>
 <form method="get" class="sc-searchform" action="<?php echo esc_url( home_url( '/' ) ); ?>" role="search">
-	<label class="screen-reader-text" for="sc-searchform-field-<?php echo isset( $sc_index ) ? absint( $sc_index ) : 0; ?>"><?php esc_html_e( 'Search for:', 'scaffolding' ); ?></label>
-	<input type="search" class="sc-searchform-field" name="s" id="sc-searchform-field-<?php echo isset( $sc_index ) ? absint( $sc_index ) : 0; ?>" value="<?php echo esc_attr( get_search_query() ); ?>" placeholder="<?php esc_attr_e( 'Search the Site&hellip;', 'scaffolding' ); ?>">
+	<label class="screen-reader-text" for="sc-searchform-field-<?php echo isset( $scaffolding_index ) ? absint( $scaffolding_index ) : 0; ?>"><?php esc_html_e( 'Search for:', 'scaffolding' ); ?></label>
+	<input type="search" class="sc-searchform-field" name="s" id="sc-searchform-field-<?php echo isset( $scaffolding_index ) ? absint( $scaffolding_index ) : 0; ?>" value="<?php echo esc_attr( get_search_query() ); ?>" placeholder="<?php esc_attr_e( 'Search the Site&hellip;', 'scaffolding' ); ?>">
 	<button type="submit" value="<?php esc_attr_e( 'Search', 'scaffolding' ); ?>"><?php esc_attr_e( 'Go', 'scaffolding' ); ?></button>
 </form>

--- a/sidebar.php
+++ b/sidebar.php
@@ -7,12 +7,12 @@
  * @package Scaffolding
  */
 
-global $sc_sidebar_class;
+global $scaffolding_sidebar_class;
 
 if ( is_active_sidebar( 'left-sidebar' ) ) :
 	?>
 
-	<div id="left-sidebar" class="sidebar <?php echo esc_attr( $sc_sidebar_class['left'] ); ?>" role="complementary">
+	<div id="left-sidebar" class="sidebar <?php echo esc_attr( $scaffolding_sidebar_class['left'] ); ?>" role="complementary">
 		<?php dynamic_sidebar( 'left-sidebar' ); ?>
 	</div>
 
@@ -22,7 +22,7 @@ endif;
 if ( is_active_sidebar( 'right-sidebar' ) ) :
 	?>
 
-	<div id="right-sidebar" class="sidebar <?php echo esc_attr( $sc_sidebar_class['right'] ); ?>" role="complementary">
+	<div id="right-sidebar" class="sidebar <?php echo esc_attr( $scaffolding_sidebar_class['right'] ); ?>" role="complementary">
 		<?php dynamic_sidebar( 'right-sidebar' ); ?>
 	</div>
 

--- a/single.php
+++ b/single.php
@@ -9,14 +9,14 @@
 
 get_header();
 
-global $sc_layout_class;
+global $scaffolding_layout_class;
 ?>
 
 <div id="inner-content" class="container">
 
-	<div class="row <?php echo esc_attr( $sc_layout_class['row'] ); ?>">
+	<div class="row <?php echo esc_attr( $scaffolding_layout_class['row'] ); ?>">
 
-		<div id="main" class="<?php echo esc_attr( $sc_layout_class['main'] ); ?> clearfix" role="main">
+		<div id="main" class="<?php echo esc_attr( $scaffolding_layout_class['main'] ); ?> clearfix" role="main">
 
 			<?php
 			if ( have_posts() ) :

--- a/templates/site-map.php
+++ b/templates/site-map.php
@@ -7,7 +7,7 @@
 
 get_header();
 
-global $sc_layout_class;
+global $scaffolding_layout_class;
 
 /**
  * Return array of excluded term IDs
@@ -183,9 +183,9 @@ function scaffolding_list_posts( $post_type, $args = array() ) {
 
 <div id="inner-content" class="container">
 
-	<div class="row <?php echo esc_attr( $sc_layout_class['row'] ); ?>">
+	<div class="row <?php echo esc_attr( $scaffolding_layout_class['row'] ); ?>">
 
-		<div id="main" class="<?php echo esc_attr( $sc_layout_class['main'] ); ?> clearfix" role="main">
+		<div id="main" class="<?php echo esc_attr( $scaffolding_layout_class['main'] ); ?> clearfix" role="main">
 
 			<?php
 			if ( have_posts() ) :
@@ -223,15 +223,15 @@ function scaffolding_list_posts( $post_type, $args = array() ) {
 									<h3><?php esc_html_e( 'Pages', 'scaffolding' ); ?></h3>
 									<ul>
 										<?php
-										$sc_page_args         = array(
+										$scaffolding_page_args         = array(
 											'sort_column' => 'post_title',
 											'title_li'    => '',
 										);
-										$sc_excluded_page_ids = scaffolding_excluded_posts( 'page' );
-										if ( ! empty( $sc_excluded_page_ids ) ) {
-											$sc_page_args['exclude'] = $sc_excluded_page_ids;
+										$scaffolding_excluded_page_ids = scaffolding_excluded_posts( 'page' );
+										if ( ! empty( $scaffolding_excluded_page_ids ) ) {
+											$scaffolding_page_args['exclude'] = $scaffolding_excluded_page_ids;
 										}
-										wp_list_pages( $sc_page_args );
+										wp_list_pages( $scaffolding_page_args );
 										?>
 									</ul>
 


### PR DESCRIPTION
* add exclusions for phpcs for third party libraries in `phpcs.xml.dist`
* fix phpcs issues in javascript files
* replace `sc_` prefix with `scaffolding_` prefix.
  * phpcs now throws this error for short prefixes:
  *  > The "sc" prefix is too short. Short prefixes are not unique enough and may cause name collisions with other code.
* Fix or ignore phpcs issues in the php files.

